### PR TITLE
feat: add release date and modules version

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -39,6 +39,9 @@ The data returned by this module follows a pretty specific structure. Here's a d
           - `minor` (`String`) - the semver minor number.
           - `patch` (`String`) - the semver patch number.
           - `line` (`String`) - the "name" of the release line.
+        - `releaseDate` (`String`) - the version's release date.
+        - `modules` (`Object`)
+          - `version` (`String`) - the ABI (Application Binary Interface) version number of Node.js, used to determine which version of Node.js compiled C++ add-on binaries can be loaded in to without needing to be re-compiled.
         - `dependencies` (`Object`) - the bundled dependencies in this version of Node.js:
           - `npm` (`String`) - version of the bundled npm. 
           - `v8` (`String`) - version of the bundled v8.

--- a/core/index.js
+++ b/core/index.js
@@ -45,6 +45,14 @@ async function core (options) {
 
     data[name].releases[`v${versionSemver.version}`].semver = semverToReturn
 
+    data[name].releases[`v${versionSemver.version}`].releaseDate = versions[version].date ?? undefined
+
+    const modules = {
+      version: versions[version].modules ?? undefined
+    }
+
+    data[name].releases[`v${versionSemver.version}`].modules = modules
+
     // define the dependencies object
     data[name].releases[`v${versionSemver.version}`].dependencies = {}
 

--- a/core/test/static-values.js
+++ b/core/test/static-values.js
@@ -8,6 +8,21 @@ const beforeEachTemplate = require('../util/dev/beforeEachTemplate')
 describe('check that we get the values we expect from values that should not ever change', async () => {
   beforeEach(beforeEachTemplate)
 
+  it('should have some correct values for release date', async () => {
+    const staticData = await nodevu()
+    assert.deepStrictEqual(staticData.v20.releases['v20.2.0'].releaseDate, '2023-05-16')
+    assert.deepStrictEqual(staticData.v9.releases['v9.5.0'].releaseDate, '2018-01-31')
+    assert.deepStrictEqual(staticData['v0.1'].releases['v0.1.14'].releaseDate, '2011-08-26')
+  })
+
+  it('should have some correct values for modules', async () => {
+    const staticData = await nodevu()
+    assert.deepStrictEqual(staticData.v20.releases['v20.2.0'].modules.version, '115')
+    assert.deepStrictEqual(staticData.v10.releases['v10.20.1'].modules.version, '64')
+    assert.deepStrictEqual(staticData['v0.2'].releases['v0.2.0'].modules.version, '1')
+    assert.deepStrictEqual(staticData['v0.1'].releases['v0.1.14'].modules.version, undefined)
+  })
+
   it('should have some correct values for Node.js dependencies', async () => {
     const staticData = await nodevu()
     assert.deepStrictEqual(staticData.v17.releases['v17.0.0'].dependencies.npm, '8.1.0')


### PR DESCRIPTION
Hi @bnb ,

Background:
We are currently consolidating the Node releases data logic/code in `nodejs/nodejs.org` repo (I am referencing this [PR](https://github.com/nodejs/nodejs.org/pull/5365)). And the repo has been using `nodevu` for some time. Then we found out that there are some fields that we need but not returned by `nodevu` yet.

We need these 2 new fields:
- `date` -> fetched from `index.json` and it's not the same with `support.phases.dates.start`. I am not too sure myself about the historical context behind it. However, it seems like: release date in `index.json` is referring to actual the release date and `support.phases.dates.start` is referring to the support start date ("current" status starts).
- `modules.version` -> fetched from `index.json` as well, see [this](https://nodejs.org/en/download/releases#backref-1) for explanation.

This PR is still in draft state (I haven't added any test or added to the docs), looking forward for your inputs/feedbacks.