### PR TITLE
chore: update tooling for updates

### DIFF
--- a/aliases/package.json
+++ b/aliases/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "lint": "standard --env mocha",
     "lint:fix": "standard --fix --env mocha",
-    "updates": "npx npm-check-updates"
+    "updates:check": "npx npm-check-updates",
+    "updates:update": "npx npm-check-updates -u"
   },
   "devDependencies": {
     "standard": "^17.0.0"

--- a/core/package.json
+++ b/core/package.json
@@ -21,14 +21,14 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@nodevu/parsefiles": "^0.0.2",
-    "luxon": "^3.0.4",
-    "semver": "^7.3.7",
-    "undici": "^5.10.0"
+    "@nodevu/parsefiles": "^0.0.3",
+    "luxon": "^3.3.0",
+    "semver": "^7.5.1",
+    "undici": "^5.22.1"
   },
   "devDependencies": {
     "nyc": "^15.1.0",
     "standard": "^17.0.0",
-    "test": "^3.2.1"
+    "test": "^3.3.0"
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -11,7 +11,8 @@
     "test:update:static": "node ./util/dev/updateStaticData.js",
     "test:update:now": "node ./util/dev/updateStaticNow.js",
     "coverage": "nyc node--test",
-    "updates": "npx npm-check-updates"
+    "updates:check": "npx npm-check-updates",
+    "updates:update": "npx npm-check-updates -u"
   },
   "author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
   "license": "MIT",

--- a/earliest/package.json
+++ b/earliest/package.json
@@ -12,7 +12,8 @@
     "lint:fix": "standard --fix --env mocha",
     "test": "node--test",
     "coverage": "nyc node--test",
-    "updates": "npx npm-check-updates"
+    "updates:check": "npx npm-check-updates",
+    "updates:update": "npx npm-check-updates -u"
   },
   "repository": {
     "type": "git",

--- a/earliest/package.json
+++ b/earliest/package.json
@@ -35,6 +35,6 @@
   "devDependencies": {
     "nyc": "^15.1.0",
     "standard": "^17.0.0",
-    "test": "^3.2.1"
+    "test": "^3.3.0"
   }
 }

--- a/parsefiles/package.json
+++ b/parsefiles/package.json
@@ -8,7 +8,8 @@
     "lint:fix": "standard --fix --env mocha",
     "test": "node--test",
     "coverage": "nyc mocha",
-    "updates": "npx npm-check-updates"
+    "updates:check": "npx npm-check-updates",
+    "updates:update": "npx npm-check-updates -u"
   },
   "keywords": [
     "node.js",

--- a/parsefiles/package.json
+++ b/parsefiles/package.json
@@ -26,6 +26,6 @@
   "devDependencies": {
     "nyc": "^15.1.0",
     "standard": "^17.0.0",
-    "test": "^3.2.1"
+    "test": "^3.3.0"
   }
 }

--- a/ranges/package.json
+++ b/ranges/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "nyc": "^15.1.0",
     "standard": "^17.0.0",
-    "test": "^3.2.1"
+    "test": "^3.3.0"
   }
 }

--- a/ranges/package.json
+++ b/ranges/package.json
@@ -12,7 +12,8 @@
     "lint:fix": "standard --fix --env mocha",
     "test": "node--test",
     "coverage": "nyc node--test",
-    "updates": "npx npm-check-updates"
+    "updates:check": "npx npm-check-updates",
+    "updates:update": "npx npm-check-updates -u"
   },
   "repository": {
     "type": "git",

--- a/static/package.json
+++ b/static/package.json
@@ -40,6 +40,6 @@
   "devDependencies": {
     "nyc": "^15.1.0",
     "standard": "^17.0.0",
-    "test": "^3.2.1"
+    "test": "^3.3.0"
   }
 }

--- a/static/package.json
+++ b/static/package.json
@@ -14,7 +14,8 @@
     "prepublish": "npm run build",
     "test": "node--test",
     "coverage": "nyc node--test",
-    "updates": "npx npm-check-updates"
+    "updates:check": "npx npm-check-updates",
+    "updates:update": "npx npm-check-updates -u"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the `update` script in every package to be two scripts: `updates:check` and `updates:update`. Ideally this allows for easier maintenance of dependencies (since npm still doesn't have an equivalent feature) plus allows us to run a cron GitHub Action to automatically update our dependencies.