### PR TITLE
chore: use default fetch instead of undici

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -1,4 +1,3 @@
-const { fetch: defaultFetch } = require('undici')
 const { DateTime } = require('luxon')
 const semver = require('semver')
 const parsefiles = require('@nodevu/parsefiles')
@@ -194,7 +193,7 @@ async function determineCurrentReleasePhase (now, dates = {}) {
 async function parseOptions (options) {
   // set up our defaults
   const parsedOptions = {
-    fetch: await defaultFetch,
+    fetch: fetch,
     now: DateTime.now(),
     urls: {
       index: 'https://nodejs.org/dist/index.json',

--- a/core/package.json
+++ b/core/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "@nodevu/parsefiles": "^0.0.3",
     "luxon": "^3.3.0",
-    "semver": "^7.5.1",
-    "undici": "^5.22.1"
+    "semver": "^7.5.1"
   },
   "devDependencies": {
     "nyc": "^15.1.0",


### PR DESCRIPTION
This PR allows `nodevu` to not break on non-node environments because it enforces undici. Whilst `undici` is awesome, by doing `await defaultFetch` (where defaultFetch is the undici import) it makes the library rent unusable on mixed server-client environments or on a pure client fashion.