### PR TITLE
ci: add, update, and improve Actions for linting and CI

### DIFF
--- a/.github/workflows/lint-aliases.yml
+++ b/.github/workflows/lint-aliases.yml
@@ -1,8 +1,10 @@
-name: "Test Suite: Linter"
+name: "Test Suite: Linter (aliases)"
 
 on:
   push:
   pull_request:
+    paths:
+        - 'aliases/**'
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: current
-    - name: Run npm install
-      run: npm install -ws
-    - name: Run npm lint
-      run: npm run lint
-      
+    - name: Run npm install -w aliases
+      run: npm install -w aliases
+    - name: Run npm run lint -w aliases
+      run: npm run lint -w aliases

--- a/.github/workflows/lint-core.yml
+++ b/.github/workflows/lint-core.yml
@@ -1,8 +1,10 @@
-name: "Test Suite: Linter"
+name: "Test Suite: Linter (core)"
 
 on:
   push:
   pull_request:
+    paths:
+        - 'core/**'
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: current
-    - name: Run npm install
-      run: npm install -ws
-    - name: Run npm lint
-      run: npm run lint
-      
+    - name: Run npm install -w core
+      run: npm install -w core
+    - name: Run npm run lint -w core
+      run: npm run lint -w core

--- a/.github/workflows/lint-earliest.yml
+++ b/.github/workflows/lint-earliest.yml
@@ -1,8 +1,10 @@
-name: "Test Suite: Linter"
+name: "Test Suite: Linter (earliest)"
 
 on:
   push:
   pull_request:
+    paths:
+        - 'earliest/**'
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: current
-    - name: Run npm install
-      run: npm install -ws
-    - name: Run npm lint
-      run: npm run lint
-      
+    - name: Run npm install -w earliest
+      run: npm install -w earliest
+    - name: Run npm run lint -w earliest
+      run: npm run lint -w earliest

--- a/.github/workflows/lint-parsefiles.yml
+++ b/.github/workflows/lint-parsefiles.yml
@@ -1,8 +1,10 @@
-name: "Test Suite: Linter"
+name: "Test Suite: Linter (parsefiles)"
 
 on:
   push:
   pull_request:
+    paths:
+        - 'parsefiles/**'
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: current
-    - name: Run npm install
-      run: npm install -ws
-    - name: Run npm lint
-      run: npm run lint
-      
+    - name: Run npm install -w parsefiles
+      run: npm install -w parsefiles
+    - name: Run npm run lint -w parsefiles
+      run: npm run lint -w parsefiles

--- a/.github/workflows/lint-ranges.yml
+++ b/.github/workflows/lint-ranges.yml
@@ -1,8 +1,10 @@
-name: "Test Suite: Linter"
+name: "Test Suite: Linter (ranges)"
 
 on:
   push:
   pull_request:
+    paths:
+        - 'ranges/**'
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: current
-    - name: Run npm install
-      run: npm install -ws
-    - name: Run npm lint
-      run: npm run lint
-      
+    - name: Run npm install -w ranges
+      run: npm install -w ranges
+    - name: Run npm run lint -w ranges
+      run: npm run lint -w ranges

--- a/.github/workflows/lint-static.yml
+++ b/.github/workflows/lint-static.yml
@@ -1,8 +1,10 @@
-name: "Test Suite: Linter"
+name: "Test Suite: Linter (static)"
 
 on:
   push:
   pull_request:
+    paths:
+        - 'static/**'
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: current
-    - name: Run npm install
-      run: npm install -ws
-    - name: Run npm lint
-      run: npm run lint
-      
+    - name: Run npm install -w static
+      run: npm install -w static
+    - name: Run npm run lint -w static
+      run: npm run lint -w static

--- a/.github/workflows/lint-translate.yml
+++ b/.github/workflows/lint-translate.yml
@@ -1,8 +1,10 @@
-name: "Test Suite: Linter"
+name: "Test Suite: Linter (translate)"
 
 on:
   push:
   pull_request:
+    paths:
+        - 'translate/**'
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +20,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: current
-    - name: Run npm install
-      run: npm install -ws
-    - name: Run npm lint
-      run: npm run lint
-      
+    - name: Run npm install -w translate
+      run: npm install -w translate
+    - name: Run npm run lint -w translate
+      run: npm run lint -w translate

--- a/.github/workflows/nightly-static-build.yaml
+++ b/.github/workflows/nightly-static-build.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/tests-core.yml
+++ b/.github/workflows/tests-core.yml
@@ -1,0 +1,30 @@
+name: "Test Suite: @nodevu/core"
+
+on:
+  pull_request:
+    paths:
+      - 'core/**'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  tests:
+    if: github.repository == 'cutenode/nodevu'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [current, lts/*, lts/-1, lts/-2]
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install most recent npm
+      run: npm install -g npm
+    - name: Run npm install -w core
+      run: npm install -w core
+    - name: Run npm test -w core
+      run: npm test -w core

--- a/.github/workflows/tests-core.yml
+++ b/.github/workflows/tests-core.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [current, lts/*, lts/-1, lts/-2]
+        node-version: [current, lts/*, lts/-1]
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/tests-earliest.yml
+++ b/.github/workflows/tests-earliest.yml
@@ -1,0 +1,30 @@
+name: "Test Suite: @nodevu/core"
+
+on:
+  pull_request:
+    paths:
+      - 'earliest/**'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  tests:
+    if: github.repository == 'cutenode/nodevu'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [current, lts/*, lts/-1, lts/-2]
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install most recent npm
+      run: npm install -g npm
+    - name: Run npm install -w earliest
+      run: npm install -w earliest
+    - name: Run npm test -w earliest
+      run: npm test -w earliest

--- a/.github/workflows/tests-earliest.yml
+++ b/.github/workflows/tests-earliest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [current, lts/*, lts/-1, lts/-2]
+        node-version: [current, lts/*, lts/-1]
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/tests-parsefiles.yml
+++ b/.github/workflows/tests-parsefiles.yml
@@ -1,9 +1,9 @@
-name: "Test Suite: @nodevu/translate"
+name: "Test Suite: @nodevu/core"
 
 on:
   pull_request:
     paths:
-      - 'translate/**'
+      - 'parsefiles/**'
     branches:
       - main
   workflow_dispatch:
@@ -14,19 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [current, lts/*, lts/-1]
+        node-version: [current, lts/*, lts/-1, lts/-2]
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Install latest npm
-      run: npm i -g npm
-    - name: Run npm install (project)
-      run: npm install
-    - name: Run npm install (package)
-      run: npm install -w translate
-    - name: Run npm test
-      run: npm test -w translate
+    - name: Install most recent npm
+      run: npm install -g npm
+    - name: Run npm install -w parsefiles
+      run: npm install -w parsefiles
+    - name: Run npm test -w parsefiles
+      run: npm test -w parsefiles

--- a/.github/workflows/tests-parsefiles.yml
+++ b/.github/workflows/tests-parsefiles.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [current, lts/*, lts/-1, lts/-2]
+        node-version: [current, lts/*, lts/-1]
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/tests-ranges.yml
+++ b/.github/workflows/tests-ranges.yml
@@ -1,9 +1,9 @@
-name: "Test Suite: @nodevu/core"
+name: "Test Suite: @nodevu/ranges"
 
 on:
   pull_request:
     paths:
-      - 'core/**'
+      - 'ranges/*'
     branches:
       - main
   workflow_dispatch:
@@ -14,15 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [current, lts/*, lts/-1, lts/-2]
+        node-version: [current, lts/*, lts/-1]
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Run npm install
-      run: npm install -w core
-    - name: Run npm test
-      run: npm test -w core
+    - name: Install most recent npm
+      run: npm install -g npm
+    - name: Run npm install -w ranges
+      run: npm install -w ranges
+    - name: Run npm test -w ranges
+      run: npm test -w ranges

--- a/.github/workflows/tests-static.yml
+++ b/.github/workflows/tests-static.yml
@@ -17,14 +17,14 @@ jobs:
         node-version: [current, lts/*, lts/-1, lts/-2]
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Install latest npm
-      run: npm i -g npm
-    - name: Run npm install
+    - name: Install most recent npm
+      run: npm install -g npm
+    - name: Run npm install -w static
       run: npm install -w static
-    - name: Run npm test
+    - name: Run npm test -w static
       run: npm test -w static

--- a/.github/workflows/tests-static.yml
+++ b/.github/workflows/tests-static.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [current, lts/*, lts/-1, lts/-2]
+        node-version: [current, lts/*, lts/-1]
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4

--- a/.github/workflows/tests-translate.yml
+++ b/.github/workflows/tests-translate.yml
@@ -1,9 +1,9 @@
-name: "Test Suite: @nodevu/ranges"
+name: "Test Suite: @nodevu/translate"
 
 on:
   pull_request:
     paths:
-      - 'ranges/*'
+      - 'translate/**'
     branches:
       - main
   workflow_dispatch:
@@ -17,16 +17,14 @@ jobs:
         node-version: [current, lts/*, lts/-1]
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Install latest npm
-      run: npm i -g npm
-    - name: Run npm install at the monorepo level
-      run: npm install
-    - name: Run npm install at the package level
-      run: npm install -w ranges
-    - name: Run npm test
-      run: npm test -w ranges
+    - name: Install most recent npm
+      run: npm install -g npm
+    - name: Run npm install -w translate
+      run: npm install -w translate
+    - name: Run npm test -w translate
+      run: npm test -w translate

--- a/parsefiles/test/test.js
+++ b/parsefiles/test/test.js
@@ -5,7 +5,6 @@ const parseFiles = require('../index')
 const input = require('./data/input.json')
 const expected = require('./data/expected.json')
 
-
 const mockverson = '420.420.420'
 
 // this will cover most cases!

--- a/translate/examples/default.js
+++ b/translate/examples/default.js
@@ -19,11 +19,11 @@ async function getTranslatedData () {
 
   // return the data in a single object
   return {
-    "current": translatedCurrent,
-    "lts_latest": translatedLtsLatest,
-    "lts": translatedLts,
-    "supported": translatedSupported,
-    "all": translatedAll
+    current: translatedCurrent,
+    lts_latest: translatedLtsLatest,
+    lts: translatedLts,
+    supported: translatedSupported,
+    all: translatedAll
   }
 }
 


### PR DESCRIPTION
This PR:

- Tweaks existing testing Actions, making them more uniform (both in terms of scripts run and naming)
- Adds missing testing Actions, where tests exist
- Adds linting Actions for each individual package
  - This does not remove the existing linting Action. While the individual package CI linting is now duplicated, I want to leave it like this for a minute just to make sure that we're not missing anything in the change.
- Updates Actions to use checkout v4