### PR TITLE
ci: add formatter step to nightly static build

### DIFF
--- a/.github/workflows/nightly-static-build.yaml
+++ b/.github/workflows/nightly-static-build.yaml
@@ -23,6 +23,8 @@ jobs:
         run: npm run build:security -w static
       - name: Run build:support
         run: npm run build:support -w static
+      - name: Format Output
+        run: npm run lint:apply -w static
       - name: Create or Update Pull Request
         uses: gr2m/create-or-update-pull-request-action@v1
         env:


### PR DESCRIPTION
adds a formatter step to the nightly build so the files aren't borked