### PR TITLE
fix: remove async wrapper around static builders

### DIFF
--- a/static/build/releases.js
+++ b/static/build/releases.js
@@ -5,11 +5,10 @@ async function writeReleases(filename) {
 	const data = await nodevu();
 	const releases = {};
 
-	async () => {
-		for await (const verison of Object.keys(data)) {
-			releases[version] = data[version].releases;
-		}
-	};
+	for await (const version of Object.keys(data)) {
+		releases[version] = data[version].releases;
+	}
+
 	write('./static/data/releases.json', releases);
 }
 

--- a/static/build/security.js
+++ b/static/build/security.js
@@ -5,11 +5,10 @@ async function writeSecurity(filename) {
 	const data = await nodevu();
 	const security = {};
 
-	async () => {
-		for await (const version of Object.keys(data)) {
-			security[version] = data[version].security;
-		}
-	};
+	for await (const version of Object.keys(data)) {
+		security[version] = data[version].security;
+	}
+
 	write('./static/data/security.json', security);
 }
 

--- a/static/build/support.js
+++ b/static/build/support.js
@@ -5,11 +5,10 @@ async function writeSupport(filename) {
 	const data = await nodevu();
 	const support = {};
 
-	async () => {
-		for await (const version of Object.keys(data)) {
-			support[version] = data[version].support;
-		}
-	};
+	for await (const version of Object.keys(data)) {
+		support[version] = data[version].support;
+	}
+
 	write('./static/data/support.json', support);
 }
 


### PR DESCRIPTION
removes an anonymous async wrapper around for... await loops in the static builders. Also fixes a typo in one of them. I'm not sure how it ever worked...