### PR TITLE
ci: add "workflow_call:" to all linter and test Actions

### DIFF
--- a/.github/workflows/lint-aliases.yml
+++ b/.github/workflows/lint-aliases.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/lint-core.yml
+++ b/.github/workflows/lint-core.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/lint-earliest.yml
+++ b/.github/workflows/lint-earliest.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/lint-parsefiles.yml
+++ b/.github/workflows/lint-parsefiles.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/lint-ranges.yml
+++ b/.github/workflows/lint-ranges.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/lint-static.yml
+++ b/.github/workflows/lint-static.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/lint-translate.yml
+++ b/.github/workflows/lint-translate.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/tests-core.yml
+++ b/.github/workflows/tests-core.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/tests-earliest.yml
+++ b/.github/workflows/tests-earliest.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/tests-parsefiles.yml
+++ b/.github/workflows/tests-parsefiles.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/tests-ranges.yml
+++ b/.github/workflows/tests-ranges.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/tests-static.yml
+++ b/.github/workflows/tests-static.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/tests-translate.yml
+++ b/.github/workflows/tests-translate.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   tests:


### PR DESCRIPTION
adds `workflow_call` to all linter and test actions so they can ideally run on PRs created by GitHub Actions