### PR TITLE
ci: add automated publishing for core and static

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -1,0 +1,22 @@
+name: Publish @nodevu/core to npmjs
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -w core
+      - run: npm run lint -w core
+      - run: npm run coverage -w core
+      - run: npm publish --provenance --access public -w core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-static.yml
+++ b/.github/workflows/publish-static.yml
@@ -1,0 +1,22 @@
+name: Publish @nodevu/static to npmjs
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -w static
+      - run: npm run lint -w static
+      - run: npm run coverage -w static
+      - run: npm publish --provenance --access public -w static
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows to automate the publishing of the `@nodevu/core` and `@nodevu/static` packages to npm. The workflows are triggered manually via the `workflow_dispatch` event and include steps for setting up the environment, running tests, and publishing the packages.

New GitHub Actions workflows for publishing packages:

* [`.github/workflows/publish-core.yml`](diffhunk://#diff-63a2aec349a5cea5f929f0b2bb5ed2946627331587e46f3382c7df8239fb9030R1-R22): Added a workflow to publish the `@nodevu/core` package to npm. This includes steps for checking out the code, setting up Node.js, installing dependencies, running lint and coverage checks, and publishing the package.
* [`.github/workflows/publish-static.yml`](diffhunk://#diff-3d3b3f8ad5d881db76299c1ee2db732873d77bc0137342511c3fe117e80f3224R1-R22): Added a workflow to publish the `@nodevu/static` package to npm. This follows the same steps as the core package workflow, ensuring consistency in the publishing process.