### PR TITLE
chore: update deps in @nodevu/core

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -5,7 +5,7 @@
 	"main": "index.js",
 	"scripts": {
 		"lint": "biome check ./",
-		"lint:apply": "biome check ./ --apply",
+		"lint:write": "biome check ./ --write",
 		"test": "node--test",
 		"test:update": "npm run test:update:static && npm run test:update:now",
 		"test:update:static": "node ./util/dev/updateStaticData.js",
@@ -19,13 +19,13 @@
 	"files": ["index.js", "LICENSE"],
 	"dependencies": {
 		"@nodevu/parsefiles": "^0.0.3",
-		"luxon": "^3.3.0",
-		"semver": "^7.5.1"
+		"luxon": "^3.5.0",
+		"semver": "^7.6.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.6.1",
-		"nyc": "^15.1.0",
+		"@biomejs/biome": "1.9.4",
+		"nyc": "^17.1.0",
 		"test": "^3.3.0",
-		"undici": "^5.22.1"
+		"undici": "^6.20.1"
 	}
 }


### PR DESCRIPTION
This pull request includes updates to the `core/package.json` file to modify script names and update dependencies.

Changes to scripts:
* Renamed the `lint:apply` script to `lint:write` for consistency.

Dependency updates:
* Updated `luxon` from version `^3.3.0` to `^3.5.0`.
* Updated `semver` from version `^7.5.1` to `^7.6.3`.
* Updated `@biomejs/biome` from version `1.6.1` to `1.9.4`.
* Updated `nyc` from version `^15.1.0` to `^17.1.0`.
* Updated `undici` from version `^5.22.1` to `^6.20.1`.