### PR TITLE
chore: update dependencies and tooling in all packages

### DIFF
--- a/aliases/package.json
+++ b/aliases/package.json
@@ -7,7 +7,10 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": ["node.js", "version"],
+	"keywords": [
+		"node.js",
+		"version"
+	],
 	"author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
 	"license": "MIT",
 	"bugs": {
@@ -16,12 +19,12 @@
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"scripts": {
 		"lint": "biome check ./",
-		"lint:apply": "biome check ./ --apply",
+		"lint:write": "biome check ./ --write",
 		"test": "",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.6.1"
+		"@biomejs/biome": "1.9.4"
 	}
 }

--- a/core/package.json
+++ b/core/package.json
@@ -6,11 +6,11 @@
 	"scripts": {
 		"lint": "biome check ./",
 		"lint:write": "biome check ./ --write",
-		"test": "node--test",
+		"test": "node --test",
 		"test:update": "npm run test:update:static && npm run test:update:now",
 		"test:update:static": "node ./util/dev/updateStaticData.js",
 		"test:update:now": "node ./util/dev/updateStaticNow.js",
-		"coverage": "nyc node--test",
+		"coverage": "c8 node --test",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
@@ -27,8 +27,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"nyc": "^17.1.0",
-		"test": "^3.3.0",
+		"c8": "^10.1.2",
 		"undici": "^6.20.1"
 	}
 }

--- a/earliest/package.json
+++ b/earliest/package.json
@@ -6,9 +6,9 @@
 	"files": ["index.js", "LICENSE"],
 	"scripts": {
 		"lint": "biome check ./",
-		"lint:apply": "biome check ./ --apply",
-		"test": "node--test",
-		"coverage": "nyc node--test",
+		"lint:write": "biome check ./ --write",
+		"test": "node --test",
+		"coverage": "c8 node --test",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
@@ -28,7 +28,6 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.6.1",
-		"nyc": "^15.1.0",
-		"test": "^3.3.0"
+		"c8": "^10.1.2"
 	}
 }

--- a/parsefiles/package.json
+++ b/parsefiles/package.json
@@ -5,19 +5,26 @@
 	"main": "index.js",
 	"scripts": {
 		"lint": "biome check ./",
-		"lint:apply": "biome check ./ --apply",
-		"test": "node--test",
-		"coverage": "nyc mocha",
+		"lint:write": "biome check ./ --write",
+		"test": "node --test",
+		"coverage": "c8 node --test",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
-	"keywords": ["node.js", "versions", "parse", "files"],
-	"files": ["index.js", "LICENSE"],
+	"keywords": [
+		"node.js",
+		"versions",
+		"parse",
+		"files"
+	],
+	"files": [
+		"index.js",
+		"LICENSE"
+	],
 	"author": "Tierney Cyren <hello@bnb.im>",
 	"license": "MIT",
 	"devDependencies": {
-		"@biomejs/biome": "1.6.1",
-		"nyc": "^15.1.0",
-		"test": "^3.3.0"
+		"@biomejs/biome": "1.9.4",
+		"c8": "^10.1.2"
 	}
 }

--- a/ranges/package.json
+++ b/ranges/package.json
@@ -3,12 +3,15 @@
 	"version": "0.1.0",
 	"description": "support node's unofficial alias namespace",
 	"main": "index.js",
-	"files": ["index.js", "LICENSE"],
+	"files": [
+		"index.js",
+		"LICENSE"
+	],
 	"scripts": {
 		"lint": "biome check ./",
 		"lint:write": "biome check ./ --write",
 		"test": "node --test",
-		"coverage": "nyc node --test",
+		"coverage": "c8 node --test",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
@@ -28,6 +31,6 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"nyc": "^17.1.0"
+		"c8": "^10.1.2"
 	}
 }

--- a/ranges/package.json
+++ b/ranges/package.json
@@ -6,9 +6,9 @@
 	"files": ["index.js", "LICENSE"],
 	"scripts": {
 		"lint": "biome check ./",
-		"lint:apply": "biome check ./ --apply",
-		"test": "node--test",
-		"coverage": "nyc node--test",
+		"lint:write": "biome check ./ --write",
+		"test": "node --test",
+		"coverage": "nyc node --test",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
@@ -24,11 +24,10 @@
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"dependencies": {
 		"@nodevu/aliases": "^0.0.2",
-		"@nodevu/core": "^0.0.4"
+		"@nodevu/core": "^0.2.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.6.1",
-		"nyc": "^15.1.0",
-		"test": "^3.3.0"
+		"@biomejs/biome": "1.9.4",
+		"nyc": "^17.1.0"
 	}
 }

--- a/static/package.json
+++ b/static/package.json
@@ -12,8 +12,8 @@
 		"lint": "biome check ./",
 		"lint:write": "biome check ./ --write",
 		"prepublish": "npm run build",
-		"test": "node--test",
-		"coverage": "nyc node--test",
+		"test": "node --test",
+		"coverage": "c8 node --test",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
@@ -21,8 +21,16 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": ["node.js", "version", "versions"],
-	"files": ["/data", "index.js", "LICENSE"],
+	"keywords": [
+		"node.js",
+		"version",
+		"versions"
+	],
+	"files": [
+		"/data",
+		"index.js",
+		"LICENSE"
+	],
 	"author": "Tierney Cyren <hello@bnb.im>",
 	"license": "MIT",
 	"bugs": {
@@ -31,7 +39,6 @@
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"nyc": "^17.1.0",
-		"test": "^3.3.0"
+		"c8": "^10.1.2"
 	}
 }

--- a/translate/package.json
+++ b/translate/package.json
@@ -2,7 +2,13 @@
 	"name": "@nodevu/translate",
 	"version": "0.0.1",
 	"description": "a translation layer between the nodevu naming mechanism and the Node.js supported mechanism. Neceessary for legacy interop.",
-	"keywords": ["nodevu", "node", "nodejs", "versions", "supported"],
+	"keywords": [
+		"nodevu",
+		"node",
+		"nodejs",
+		"versions",
+		"supported"
+	],
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"bugs": {
 		"url": "https://github.com/cutenode/nodevu/issues"
@@ -15,21 +21,19 @@
 	"author": "Tierney Cyren",
 	"main": "index.js",
 	"scripts": {
-		"coverage": "nyc node--test",
 		"lint": "biome check ./",
-		"lint:apply": "biome check ./ --apply",
-		"lint:packagejson": "npx sort-package-json",
-		"test": "node--test",
+		"lint:write": "biome check ./ --write",
+		"test": "node --test",
+		"coverage": "c8 node --test",
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.6.1",
+		"@biomejs/biome": "1.9.4",
 		"@nodevu/ranges": "^0.1.0",
-		"nyc": "^15.1.0",
-		"test": "^3.3.0"
+		"c8": "^10.1.2"
 	},
 	"engines": {
-		"node": ">=16.0.0"
+		"node": ">=18.0.0"
 	}
 }


### PR DESCRIPTION
updates to `@nodevu/core@0.2.0`, drops `test` and switches to using `node --test` directly for `ranges`.