### PR TITLE
fix: update test runner require and run linter

### DIFF
--- a/aliases/package.json
+++ b/aliases/package.json
@@ -7,10 +7,7 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": [
-		"node.js",
-		"version"
-	],
+	"keywords": ["node.js", "version"],
 	"author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
 	"license": "MIT",
 	"bugs": {

--- a/core/test/combos.js
+++ b/core/test/combos.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');

--- a/core/test/dynamic-values.js
+++ b/core/test/dynamic-values.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');
 

--- a/core/test/parseOptions.js
+++ b/core/test/parseOptions.js
@@ -1,5 +1,5 @@
 const { deepStrictEqual } = require('node:assert');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 const { DateTime } = require('luxon');
 const nodevu = require('../index');

--- a/core/test/schedule.js
+++ b/core/test/schedule.js
@@ -1,5 +1,5 @@
 const { deepStrictEqual } = require('node:assert');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 const { DateTime } = require('luxon');
 const nodevu = require('../index');

--- a/core/test/static-values.js
+++ b/core/test/static-values.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');
 

--- a/core/test/unique-source.js
+++ b/core/test/unique-source.js
@@ -1,6 +1,6 @@
 const { deepStrictEqual } = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');
 

--- a/core/test/versions.js
+++ b/core/test/versions.js
@@ -1,5 +1,5 @@
 const { deepStrictEqual } = require('node:assert');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 const { DateTime } = require('luxon');
 const nodevu = require('../index');

--- a/earliest/test/test.js
+++ b/earliest/test/test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const { earliest, lts, security } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('check v10', async () => {
 	describe('running earliest', async () => {

--- a/parsefiles/package.json
+++ b/parsefiles/package.json
@@ -11,16 +11,8 @@
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
-	"keywords": [
-		"node.js",
-		"versions",
-		"parse",
-		"files"
-	],
-	"files": [
-		"index.js",
-		"LICENSE"
-	],
+	"keywords": ["node.js", "versions", "parse", "files"],
+	"files": ["index.js", "LICENSE"],
 	"author": "Tierney Cyren <hello@bnb.im>",
 	"license": "MIT",
 	"devDependencies": {

--- a/parsefiles/test/test.js
+++ b/parsefiles/test/test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 const parseFiles = require('../index');
 const input = require('./data/input.json');

--- a/ranges/package.json
+++ b/ranges/package.json
@@ -3,10 +3,7 @@
 	"version": "0.1.0",
 	"description": "support node's unofficial alias namespace",
 	"main": "index.js",
-	"files": [
-		"index.js",
-		"LICENSE"
-	],
+	"files": ["index.js", "LICENSE"],
 	"scripts": {
 		"lint": "biome check ./",
 		"lint:write": "biome check ./ --write",

--- a/ranges/test/default.test.js
+++ b/ranges/test/default.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('data should exist as it is defined', async () => {
 	it('versions should have correct types on every property', async () => {

--- a/ranges/test/known.test.js
+++ b/ranges/test/known.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('check some values we know should exist', async () => {
 	it('should include some known, static values in "all"', async () => {

--- a/ranges/test/matrixAlias.test.js
+++ b/ranges/test/matrixAlias.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // this is a non-exhaustive list of sets of aliases.
 // please feel free to add more.

--- a/ranges/test/singleAlias.test.js
+++ b/ranges/test/singleAlias.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('data should exist as it is defined when calling a single alias', async () => {
 	it('versions should have correct types on every property if an array with "all" is passed', async () => {

--- a/ranges/test/unknownFilter.test.js
+++ b/ranges/test/unknownFilter.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('failure states for arguments', async () => {
 	it('should throw an error on a string with an unknown value', async () => {

--- a/ranges/test/v.test.js
+++ b/ranges/test/v.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // tests various values to ensure that the start with the correct character
 describe('check that "v"s are where they should (and are not where they should not be)', async () => {

--- a/static/package.json
+++ b/static/package.json
@@ -21,16 +21,8 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": [
-		"node.js",
-		"version",
-		"versions"
-	],
-	"files": [
-		"/data",
-		"index.js",
-		"LICENSE"
-	],
+	"keywords": ["node.js", "version", "versions"],
+	"files": ["/data", "index.js", "LICENSE"],
 	"author": "Tierney Cyren <hello@bnb.im>",
 	"license": "MIT",
 	"bugs": {

--- a/static/test/test.default.js
+++ b/static/test/test.default.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const staticData = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/static/test/test.releases.js
+++ b/static/test/test.releases.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const staticData = require('../index');
 const { releases } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/static/test/test.security.js
+++ b/static/test/test.security.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const staticData = require('../index');
 const { security } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/static/test/test.support.js
+++ b/static/test/test.support.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const staticData = require('../index');
 const { support } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/translate/package.json
+++ b/translate/package.json
@@ -2,13 +2,7 @@
 	"name": "@nodevu/translate",
 	"version": "0.0.1",
 	"description": "a translation layer between the nodevu naming mechanism and the Node.js supported mechanism. Neceessary for legacy interop.",
-	"keywords": [
-		"nodevu",
-		"node",
-		"nodejs",
-		"versions",
-		"supported"
-	],
+	"keywords": ["nodevu", "node", "nodejs", "versions", "supported"],
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"bugs": {
 		"url": "https://github.com/cutenode/nodevu/issues"

--- a/translate/test/current.test.js
+++ b/translate/test/current.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const translate = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('test that translating current works as expected', async () => {
 	it('should return "current" when passed "current"', async () => {

--- a/translate/test/ranges.test.js
+++ b/translate/test/ranges.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const translate = require('../index');
 const ranges = require('@nodevu/ranges');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('test that each alias works with @nodevu/ranges', async () => {
 	it('should return the same result when both the translated and untranslated "current" are passed to @nodevu/ranges', async () => {


### PR DESCRIPTION
fixes the test runner require (`require('node:test')` rather than `require('test')` and runs the linter on all projects