### PR TITLE
fix: add missing property to files in @nodevu/core and fix all tests

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -16,7 +16,7 @@
 	},
 	"author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
 	"license": "MIT",
-	"files": ["index.js", "LICENSE"],
+	"files": ["index.js", "LICENSE", "/util/prod"],
 	"dependencies": {
 		"@nodevu/parsefiles": "^0.0.3",
 		"luxon": "^3.5.0",

--- a/core/test/combos.js
+++ b/core/test/combos.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');

--- a/core/test/dynamic-values.js
+++ b/core/test/dynamic-values.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');
 

--- a/core/test/parseOptions.js
+++ b/core/test/parseOptions.js
@@ -1,5 +1,5 @@
 const { deepStrictEqual } = require('node:assert');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 const { DateTime } = require('luxon');
 const nodevu = require('../index');

--- a/core/test/schedule.js
+++ b/core/test/schedule.js
@@ -1,5 +1,5 @@
 const { deepStrictEqual } = require('node:assert');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 const { DateTime } = require('luxon');
 const nodevu = require('../index');

--- a/core/test/static-values.js
+++ b/core/test/static-values.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');
 

--- a/core/test/unique-source.js
+++ b/core/test/unique-source.js
@@ -1,6 +1,6 @@
 const { deepStrictEqual } = require('node:assert');
 const nodevu = require('../index');
-const { describe, it, beforeEach } = require('test');
+const { describe, it, beforeEach } = require('node:test');
 
 const beforeEachTemplate = require('../util/dev/beforeEachTemplate');
 

--- a/core/test/versions.js
+++ b/core/test/versions.js
@@ -1,5 +1,5 @@
 const { deepStrictEqual } = require('node:assert');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 const { DateTime } = require('luxon');
 const nodevu = require('../index');

--- a/earliest/test/test.js
+++ b/earliest/test/test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const { earliest, lts, security } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('check v10', async () => {
 	describe('running earliest', async () => {

--- a/parsefiles/test/test.js
+++ b/parsefiles/test/test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 const parseFiles = require('../index');
 const input = require('./data/input.json');

--- a/ranges/test/default.test.js
+++ b/ranges/test/default.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('data should exist as it is defined', async () => {
 	it('versions should have correct types on every property', async () => {

--- a/ranges/test/known.test.js
+++ b/ranges/test/known.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('check some values we know should exist', async () => {
 	it('should include some known, static values in "all"', async () => {

--- a/ranges/test/matrixAlias.test.js
+++ b/ranges/test/matrixAlias.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // this is a non-exhaustive list of sets of aliases.
 // please feel free to add more.

--- a/ranges/test/singleAlias.test.js
+++ b/ranges/test/singleAlias.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('data should exist as it is defined when calling a single alias', async () => {
 	it('versions should have correct types on every property if an array with "all" is passed', async () => {

--- a/ranges/test/unknownFilter.test.js
+++ b/ranges/test/unknownFilter.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('failure states for arguments', async () => {
 	it('should throw an error on a string with an unknown value', async () => {

--- a/ranges/test/v.test.js
+++ b/ranges/test/v.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const ranges = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // tests various values to ensure that the start with the correct character
 describe('check that "v"s are where they should (and are not where they should not be)', async () => {

--- a/static/test/test.default.js
+++ b/static/test/test.default.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const staticData = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/static/test/test.releases.js
+++ b/static/test/test.releases.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const staticData = require('../index');
 const { releases } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/static/test/test.security.js
+++ b/static/test/test.security.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const staticData = require('../index');
 const { security } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/static/test/test.support.js
+++ b/static/test/test.support.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const staticData = require('../index');
 const { support } = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 // always feel free to add more checks here - any addition will help ensure that we're even more solid.
 //

--- a/translate/test/current.test.js
+++ b/translate/test/current.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const translate = require('../index');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('test that translating current works as expected', async () => {
 	it('should return "current" when passed "current"', async () => {

--- a/translate/test/ranges.test.js
+++ b/translate/test/ranges.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const translate = require('../index');
 const ranges = require('@nodevu/ranges');
-const { describe, it } = require('test');
+const { describe, it } = require('node:test');
 
 describe('test that each alias works with @nodevu/ranges', async () => {
 	it('should return the same result when both the translated and untranslated "current" are passed to @nodevu/ranges', async () => {


### PR DESCRIPTION
This pull request includes updates to the `files` field in `core/package.json` and changes across multiple test files to replace the `test` module with the `node:test` module.

### Updates to `files` field:

* [`core/package.json`](diffhunk://#diff-7f67769260741e2563407af949f7e54fbf0431d1c607933f6e8a8094e3219e26L19-R19): Added `/util/prod` to the `files` array.

### Test module updates:

* [`core/test/combos.js`](diffhunk://#diff-b12ceac8850fb8d522015edb0f6254dfe0a104660343827a6574fe87b4f52386L3-R3): Replaced `test` module with `node:test`.
* [`core/test/dynamic-values.js`](diffhunk://#diff-3943888aeaed896860911c5e69665506f9f02adb13a13f9a84087606fe0239a9L3-R3): Replaced `test` module with `node:test`.
* [`core/test/parseOptions.js`](diffhunk://#diff-0864bb08930a8032a357eb1ea119aaa1caab8b42bf058239053688c5aa6709ddL2-R2): Replaced `test` module with `node:test`.
* [`core/test/schedule.js`](diffhunk://#diff-c25780c8c102f4f84f2acf94154ca82ab8fc005cf2e2c48bae72227ea0b2707eL2-R2): Replaced `test` module with `node:test`.
* [`core/test/static-values.js`](diffhunk://#diff-c5db3bda81412a19b46773fa952f74701c456ac6e493e52ad2e48e2ac3d0ff82L3-R3): Replaced `test` module with `node:test`.
* [`core/test/unique-source.js`](diffhunk://#diff-257da0d5458dc95a115684bd9bf226bc8f7930121f77a2c65ae3e55658073ef9L3-R3): Replaced `test` module with `node:test`.
* [`core/test/versions.js`](diffhunk://#diff-334cd7109e31b305f7b45355a2e4b5a34a74f2f721b12e2c19a65ec2042d176aL2-R2): Replaced `test` module with `node:test`.
* [`earliest/test/test.js`](diffhunk://#diff-14e7d3d0caad4c3c869224439cb5fecd354a94d2bdcae3b6c83329ce3fc401c3L3-R3): Replaced `test` module with `node:test`.
* [`parsefiles/test/test.js`](diffhunk://#diff-b3c9a1277403c96addf248793f65bc6028b57ad8e35c5613ce7c472cace19774L2-R2): Replaced `test` module with `node:test`.
* [`ranges/test/default.test.js`](diffhunk://#diff-589b0d39855aae64462c33a654f6b2999bedd07d0abc250a12155e99b56166feL3-R3): Replaced `test` module with `node:test`.
* [`ranges/test/known.test.js`](diffhunk://#diff-910f63465969c6aadddec815e31a539fa00a3f8a1ddb14d7eaf91438808d07adL3-R3): Replaced `test` module with `node:test`.
* [`ranges/test/matrixAlias.test.js`](diffhunk://#diff-9e4ddd8411fb478f13addb937c819577b879ad5bee0dca5e1f14498255a79029L3-R3): Replaced `test` module with `node:test`.
* [`ranges/test/singleAlias.test.js`](diffhunk://#diff-35142d6b4b330bda5746bb3cebb3f62d31dc3f07e72cfb949fc02ae50c962bfbL3-R3): Replaced `test` module with `node:test`.
* [`ranges/test/unknownFilter.test.js`](diffhunk://#diff-0b7d90a5c3271b5861e788ecb273d7d5dbcaeffb2e9368a5a0875786cc027bceL3-R3): Replaced `test` module with `node:test`.
* [`ranges/test/v.test.js`](diffhunk://#diff-d40f317b40f2eb33f3483043a77f0370cb0e677f8735252baf35f1830da4846bL3-R3): Replaced `test` module with `node:test`.
* [`static/test/test.default.js`](diffhunk://#diff-a34a2c2e282323c198fe4a7b5aac3d36e7c065b893980b500007b088289e3015L3-R3): Replaced `test` module with `node:test`.
* [`static/test/test.releases.js`](diffhunk://#diff-c8ff137732abd1f971c491093ce5410c10e303b37b42dfefbddd3fcf74403dfcL4-R4): Replaced `test` module with `node:test`.
* [`static/test/test.security.js`](diffhunk://#diff-d3b2ebe0dd22cb21e03dd3629072a22f5493b355b9b29137e3a89ce20e32d74bL4-R4): Replaced `test` module with `node:test`.
* [`static/test/test.support.js`](diffhunk://#diff-6f610a717c9578fa2055177e33332f1953867347f7999dcbf7bf5434197ff5aaL4-R4): Replaced `test` module with `node:test`.