### PR TITLE
chore: update + bump earliest and ranges

### DIFF
--- a/aliases/package.json
+++ b/aliases/package.json
@@ -7,10 +7,7 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": [
-		"node.js",
-		"version"
-	],
+	"keywords": ["node.js", "version"],
 	"author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
 	"license": "MIT",
 	"bugs": {

--- a/earliest/package.json
+++ b/earliest/package.json
@@ -1,9 +1,12 @@
 {
 	"name": "@nodevu/earliest",
-	"version": "0.0.3",
+	"version": "0.1.0",
 	"description": "a module that returns the earliest lts or security release of the release line passed.",
 	"main": "index.js",
-	"files": ["index.js", "LICENSE"],
+	"files": [
+		"index.js",
+		"LICENSE"
+	],
 	"scripts": {
 		"lint": "biome check ./",
 		"lint:write": "biome check ./ --write",
@@ -16,7 +19,10 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": ["node.js", "versions"],
+	"keywords": [
+		"node.js",
+		"versions"
+	],
 	"author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
 	"license": "MIT",
 	"bugs": {
@@ -24,10 +30,10 @@
 	},
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"dependencies": {
-		"@nodevu/core": "^0.0.4"
+		"@nodevu/core": "^0.3.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.6.1",
+		"@biomejs/biome": "1.9.4",
 		"c8": "^10.1.2"
 	}
 }

--- a/earliest/package.json
+++ b/earliest/package.json
@@ -3,10 +3,7 @@
 	"version": "0.1.0",
 	"description": "a module that returns the earliest lts or security release of the release line passed.",
 	"main": "index.js",
-	"files": [
-		"index.js",
-		"LICENSE"
-	],
+	"files": ["index.js", "LICENSE"],
 	"scripts": {
 		"lint": "biome check ./",
 		"lint:write": "biome check ./ --write",
@@ -19,10 +16,7 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": [
-		"node.js",
-		"versions"
-	],
+	"keywords": ["node.js", "versions"],
 	"author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
 	"license": "MIT",
 	"bugs": {

--- a/parsefiles/package.json
+++ b/parsefiles/package.json
@@ -11,16 +11,8 @@
 		"updates:check": "npx npm-check-updates",
 		"updates:update": "npx npm-check-updates -u"
 	},
-	"keywords": [
-		"node.js",
-		"versions",
-		"parse",
-		"files"
-	],
-	"files": [
-		"index.js",
-		"LICENSE"
-	],
+	"keywords": ["node.js", "versions", "parse", "files"],
+	"files": ["index.js", "LICENSE"],
 	"author": "Tierney Cyren <hello@bnb.im>",
 	"license": "MIT",
 	"devDependencies": {

--- a/ranges/package.json
+++ b/ranges/package.json
@@ -3,10 +3,7 @@
 	"version": "0.2.0",
 	"description": "support node's unofficial alias namespace",
 	"main": "index.js",
-	"files": [
-		"index.js",
-		"LICENSE"
-	],
+	"files": ["index.js", "LICENSE"],
 	"scripts": {
 		"lint": "biome check ./",
 		"lint:write": "biome check ./ --write",

--- a/ranges/package.json
+++ b/ranges/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nodevu/ranges",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "support node's unofficial alias namespace",
 	"main": "index.js",
 	"files": [
@@ -27,7 +27,7 @@
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"dependencies": {
 		"@nodevu/aliases": "^0.0.2",
-		"@nodevu/core": "^0.2.0"
+		"@nodevu/core": "^0.3.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",

--- a/static/package.json
+++ b/static/package.json
@@ -21,16 +21,8 @@
 		"type": "git",
 		"url": "git+https://github.com/cutenode/nodevu.git"
 	},
-	"keywords": [
-		"node.js",
-		"version",
-		"versions"
-	],
-	"files": [
-		"/data",
-		"index.js",
-		"LICENSE"
-	],
+	"keywords": ["node.js", "version", "versions"],
+	"files": ["/data", "index.js", "LICENSE"],
 	"author": "Tierney Cyren <hello@bnb.im>",
 	"license": "MIT",
 	"bugs": {

--- a/translate/package.json
+++ b/translate/package.json
@@ -2,13 +2,7 @@
 	"name": "@nodevu/translate",
 	"version": "0.0.1",
 	"description": "a translation layer between the nodevu naming mechanism and the Node.js supported mechanism. Neceessary for legacy interop.",
-	"keywords": [
-		"nodevu",
-		"node",
-		"nodejs",
-		"versions",
-		"supported"
-	],
+	"keywords": ["nodevu", "node", "nodejs", "versions", "supported"],
 	"homepage": "https://github.com/cutenode/nodevu#readme",
 	"bugs": {
 		"url": "https://github.com/cutenode/nodevu/issues"


### PR DESCRIPTION
This pull request includes updates to the `package.json` files for the `earliest` and `ranges` packages, focusing on version updates and formatting improvements.

Version updates:

* Updated the version of the `@nodevu/earliest` package from `0.0.3` to `0.1.0` and the `@nodevu/ranges` package from `0.1.0` to `0.2.0`. [[1]](diffhunk://#diff-dc869942d1c47dbd36188a31555270e3ae950601562728d2e8829e68504e791aL3-R9) [[2]](diffhunk://#diff-eec0888da057c13d2f3d099ed33fa74eaa8eea7726027dd5de31cd084a1e9769L3-R3)
* Updated the `@nodevu/core` dependency version in both `earliest` and `ranges` packages to `^0.3.0`. [[1]](diffhunk://#diff-dc869942d1c47dbd36188a31555270e3ae950601562728d2e8829e68504e791aL19-R36) [[2]](diffhunk://#diff-eec0888da057c13d2f3d099ed33fa74eaa8eea7726027dd5de31cd084a1e9769L30-R30)
* Updated the `@biomejs/biome` dev dependency in the `earliest` package to `1.9.4`.

Formatting improvements:

* Reformatted the `files` and `keywords` arrays in the `earliest/package.json` file for better readability. [[1]](diffhunk://#diff-dc869942d1c47dbd36188a31555270e3ae950601562728d2e8829e68504e791aL3-R9) [[2]](diffhunk://#diff-dc869942d1c47dbd36188a31555270e3ae950601562728d2e8829e68504e791aL19-R36)