### PR TITLE
feat: add @nodevu/fetchindex

### DIFF
--- a/.github/workflows/lint-fetchindex.yml
+++ b/.github/workflows/lint-fetchindex.yml
@@ -1,0 +1,27 @@
+name: "Test Suite: Linter (@nodevu/fetchindex)"
+
+on:
+  push:
+  pull_request:
+    paths:
+        - 'fetchindex/**'
+    branches:
+      - main
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  tests:
+    if: github.repository == 'cutenode/nodevu'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: current
+    - name: Run npm install -w fetchindex
+      run: npm install -w fetchindex
+    - name: Run npm run lint -w fetchindex
+      run: npm run lint -w fetchindex

--- a/.github/workflows/publish-newest copy.yml
+++ b/.github/workflows/publish-newest copy.yml
@@ -1,0 +1,22 @@
+name: Publish @nodevu/fetchindex to npm
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -w fetchindex
+      - run: npm run lint -w fetchindex
+      - run: npm run coverage -w fetchindex
+      - run: npm publish --provenance --access public -w fetchindex
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/fetchindex/LICENSE
+++ b/fetchindex/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2022 Tierney Cyren
+
+Permission is hereby granted, free
+of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/fetchindex/README.md
+++ b/fetchindex/README.md
@@ -5,9 +5,22 @@ A tool that fetches the /dist/index.json file from the Node.js website.
 ## Usage
 
 ```js
-```
+const fetchindex = require('@nodevu/fetchindex')
 
-```js
+const options = {
+	fetch: globalThis.fetch, // use your own fetch if you want!
+	urls: {
+		index: 'https://nodejs.org/dist/index.json',
+	},
+};
+
+const index = await fetchindex(options); // returns a huge JSON object
 ```
 
 ## API
+- `fetchindex(options)`
+  - `options` (object): Options object.
+		- `fetch` (function): Fetch function. Default: `globalThis.fetch`.
+		- `urls` (object): URLs object.
+			- `index` (string): URL to fetch the index.json file from. Default: `'https://nodejs.org/dist/index.json'`.
+	- Returns: Promise that resolves with the fetched `index.json` object.

--- a/fetchindex/README.md
+++ b/fetchindex/README.md
@@ -1,0 +1,13 @@
+# @nodevu/fetchindex
+
+A tool that fetches the /dist/index.json file from the Node.js website.
+
+## Usage
+
+```js
+```
+
+```js
+```
+
+## API

--- a/fetchindex/biome.json
+++ b/fetchindex/biome.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.6.1/schema.json",
+	"organizeImports": {
+		"enabled": true
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "single"
+		}
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	}
+}

--- a/fetchindex/index.js
+++ b/fetchindex/index.js
@@ -1,0 +1,13 @@
+async function versions(options) {
+	// parse our options and set up fetch if a custom fetch is passed
+	const fetch = options.fetch;
+	const url = options.urls.index;
+
+	// fetch the url, get the json from the fetched URL that we're going to use
+	const raw = await fetch(url);
+	const versions = await raw.json();
+
+	return versions;
+}
+
+module.exports = versions;

--- a/fetchindex/package.json
+++ b/fetchindex/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@nodevu/fetchindex",
+	"version": "0.1.0",
+	"description": "A tool that fetches the /dist/index.json file from the Node.js website.",
+	"main": "index.js",
+	"files": ["index.js", "LICENSE"],
+	"scripts": {
+		"lint": "biome check ./",
+		"lint:write": "biome check ./ --write",
+		"test": "node --test",
+		"coverage": "c8 node --test",
+		"updates:check": "npx npm-check-updates",
+		"updates:update": "npx npm-check-updates -u"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/cutenode/nodevu.git"
+	},
+	"keywords": ["node.js", "versions"],
+	"author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/cutenode/nodevu/issues"
+	},
+	"homepage": "https://github.com/cutenode/nodevu#readme",
+	"devDependencies": {
+		"@biomejs/biome": "1.9.4",
+		"c8": "^10.1.2",
+		"luxon": "^3.5.0",
+		"undici": "^6.20.1"
+	}
+}

--- a/fetchindex/test/test.js
+++ b/fetchindex/test/test.js
@@ -2,8 +2,8 @@ const { deepStrictEqual } = require('node:assert');
 const { describe, it } = require('node:test');
 const { fetch: undiciFetch } = require('undici');
 const { DateTime } = require('luxon');
-const nodevu = require('../index');
-const versions = require('../index');
+const nodevu = require('@nodevu/core');
+const fetchindex = require('../index');
 const optionsParser = require('../../core/util/prod/optionsParser');
 
 // checks that verify the result of data returned
@@ -31,13 +31,13 @@ const options = {
 
 describe('under normal condiditons, versions should work', async () => {
 	it('should work with default options', async () => {
-		const data = await versions(options);
+		const data = await fetchindex(options);
 		check(data);
 	});
 
 	it('should work with Undici fetch', async () => {
 		options.fetch = undiciFetch;
-		const data = await versions(options);
+		const data = await fetchindex(options);
 		check(data);
 	});
 });
@@ -45,7 +45,7 @@ describe('under normal condiditons, versions should work', async () => {
 describe('versions should work with optionsParser', async () => {
 	it('should work with the default output of optionsParser', async () => {
 		const parsedOptions = optionsParser({});
-		const data = await versions(parsedOptions);
+		const data = await fetchindex(parsedOptions);
 		check(data);
 	});
 
@@ -53,7 +53,7 @@ describe('versions should work with optionsParser', async () => {
 		const parsedOptions = optionsParser({
 			fetch: undiciFetch,
 		});
-		const data = await versions(parsedOptions);
+		const data = await fetchindex(parsedOptions);
 		check(data);
 	});
 });

--- a/fetchindex/test/test.js
+++ b/fetchindex/test/test.js
@@ -1,0 +1,59 @@
+const { deepStrictEqual } = require('node:assert');
+const { describe, it } = require('node:test');
+const { fetch: undiciFetch } = require('undici');
+const { DateTime } = require('luxon');
+const nodevu = require('../index');
+const versions = require('../index');
+const optionsParser = require('../../core/util/prod/optionsParser');
+
+// checks that verify the result of data returned
+function check(data) {
+	deepStrictEqual(typeof data[0].version, 'string');
+	deepStrictEqual(typeof data[0].date, 'string');
+	deepStrictEqual(Array.isArray(data[0].files), true);
+	deepStrictEqual(typeof data[0].npm, 'string');
+	deepStrictEqual(typeof data[0].v8, 'string');
+	deepStrictEqual(typeof data[0].uv, 'string');
+	deepStrictEqual(typeof data[0].zlib, 'string');
+	deepStrictEqual(typeof data[0].openssl, 'string');
+	deepStrictEqual(typeof data[0].modules, 'string');
+	deepStrictEqual(typeof data[0].lts, 'boolean');
+	deepStrictEqual(typeof data[0].security, 'boolean');
+}
+
+// set up options object that would normally be passed to the module
+const options = {
+	fetch: globalThis.fetch,
+	urls: {
+		index: 'https://nodejs.org/dist/index.json',
+	},
+};
+
+describe('under normal condiditons, versions should work', async () => {
+	it('should work with default options', async () => {
+		const data = await versions(options);
+		check(data);
+	});
+
+	it('should work with Undici fetch', async () => {
+		options.fetch = undiciFetch;
+		const data = await versions(options);
+		check(data);
+	});
+});
+
+describe('versions should work with optionsParser', async () => {
+	it('should work with the default output of optionsParser', async () => {
+		const parsedOptions = optionsParser({});
+		const data = await versions(parsedOptions);
+		check(data);
+	});
+
+	it('should work with a different fetch pased to optionsParser', async () => {
+		const parsedOptions = optionsParser({
+			fetch: undiciFetch,
+		});
+		const data = await versions(parsedOptions);
+		check(data);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"newest",
 		"ranges",
 		"aliases",
-		"translate"
+		"translate",
+		"fetchindex"
 	]
 }


### PR DESCRIPTION
this PR abstracts the `util/prod/version.js` file from `@nodevu/core` into a new package, `@nodevu/fetchindex`. This is the result of a discussion with @ljharb and @wesleytodd at the Node.js Collaborator Summit in Dublin, Ireland.